### PR TITLE
Restrict fitted bin contents to [0, orig_content]

### DIFF
--- a/src/Fitter.cpp
+++ b/src/Fitter.cpp
@@ -51,14 +51,12 @@ void Fitter::fit(TH1F &spectrum, const TH2F &rema, const TH1F &start_params, TH1
 
 	fitFunction.setResponseMatrix(rema);
 
-	Double_t fit_upper_limit = 10.*start_params.GetMaximum();
-
 	for(Int_t i = 0; i <= start_params.GetNbinsX(); ++i){
 		if(i < binstart || i >= binstop){
 			fitf->FixParameter(i, 0.);
 		} else{
 			fitf->SetParameter(i, start_params.GetBinContent(i));
-			fitf->SetParLimits(i, 0., fit_upper_limit);
+			fitf->SetParLimits(i, 0., spectrum.GetBinContent(i));
 		}
 	}
 
@@ -91,14 +89,12 @@ void Fitter::fit(TH1F &spectrum, const TH2F &rema, const TH1F &start_params, TH1
 
 	fitFunction.setResponseMatrix(rema);
 
-	Double_t fit_upper_limit = 10.*start_params.GetMaximum();
-
 	for(Int_t i = 0; i <= start_params.GetNbinsX(); ++i){
 		if(i < binstart || i >= binstop){
 			fitf->FixParameter(i, 0.);
 		} else{
 			fitf->SetParameter(i, start_params.GetBinContent(i));
-			fitf->SetParLimits(i, 0., fit_upper_limit);
+			fitf->SetParLimits(i, 0., spectrum.GetBinContent(i));
 		}
 
 	}


### PR DESCRIPTION
We assume that the response matrix is triangular. Thus, it should not be
possible for bin contents to increase after deconvolution.